### PR TITLE
switch to List::SomeUtils

### DIFF
--- a/inc/My/Module/Meta.pm
+++ b/inc/My/Module/Meta.pm
@@ -71,7 +71,7 @@ sub requires {
     return {
         'Carp'			=> 0,
         'Exporter'		=> 0,
-        'List::MoreUtils'	=> 0,
+        'List::SomeUtils'	=> 0,
         'List::Util'		=> 0,
 	'PPI::Document'		=> 1.117,	# for new( readonly => 1 )
         'Scalar::Util'		=> 0,

--- a/lib/PPIx/Regexp/Element.pm
+++ b/lib/PPIx/Regexp/Element.pm
@@ -37,7 +37,7 @@ use 5.006;
 
 use Carp;
 use List::Util qw{ max min };
-use List::MoreUtils qw{ firstidx };
+use List::SomeUtils qw{ firstidx };
 use PPIx::Regexp::Util qw{ __instance };
 use Scalar::Util qw{ refaddr weaken };
 


### PR DESCRIPTION
Please consider switching to `List::SomeUtils`.  `List::MoreUtils` has a complicated build process and in my experience is less reliable:

http://matrix.cpantesters.org/?dist=List-MoreUtils+0.428
http://matrix.cpantesters.org/?dist=List-SomeUtils+0.58