### PR TITLE
Avoid "Possible attempt to escape whitespace" warning

### DIFF
--- a/lib/PPIx/Regexp/Token/Literal.pm
+++ b/lib/PPIx/Regexp/Token/Literal.pm
@@ -34,6 +34,7 @@ use warnings;
 
 use base qw{ PPIx::Regexp::Token };
 
+use PPI::Document;
 use PPIx::Regexp::Constant qw{
     COOKIE_CLASS COOKIE_REGEX_SET
     LITERAL_LEFT_CURLY_ALLOWED
@@ -202,7 +203,7 @@ my $white_space_re = $] >= 5.008 ?
 'qr< \\A [\\t\\n\\cK\\f\\r ]+ >smx';
 $white_space_re = eval $white_space_re;  ## no critic (ProhibitStringyEval)
 
-my %regex_pass_on = map { $_ => 1 } qw{ [ ] ( ) $ \ };
+my %regex_pass_on = map { $_ => 1 } ( qw{ [ ] ( ) $ }, "\\" );
 
 sub __PPIX_TOKENIZER__regexp {
     my ( undef, $tokenizer, $character ) = @_;	# Invocant, $char_type unused


### PR DESCRIPTION
... which is emitted in perl-5.43.2 and forward.