### PR TITLE
One more place where we have to avoid warning

### DIFF
--- a/lib/PPIx/Regexp/Token/Literal.pm
+++ b/lib/PPIx/Regexp/Token/Literal.pm
@@ -202,7 +202,7 @@ my $white_space_re = $] >= 5.008 ?
 'qr< \\A [\\t\\n\\cK\\f\\r ]+ >smx';
 $white_space_re = eval $white_space_re;  ## no critic (ProhibitStringyEval)
 
-my %regex_pass_on = map { $_ => 1 } qw{ [ ] ( ) $ \ };
+my %regex_pass_on = map { $_ => 1 } ( qw{ [ ] ( ) $ }, "\\");
 
 sub __PPIX_TOKENIZER__regexp {
     my ( undef, $tokenizer, $character ) = @_;	# Invocant, $char_type unused


### PR DESCRIPTION
The by now all-too-familiar "Possible attempt to escape whitespace warning."

This warning is showing up in CPANtesters reports of Perl-Critic and PLS
when built against Perl 5 blead.   We missed this location in an earlier
pull request.